### PR TITLE
feat: GitHub Logout 미작동 에러 해결

### DIFF
--- a/out/extension.js
+++ b/out/extension.js
@@ -213,7 +213,7 @@ function createAndShowWebview(context, page) {
             return;
         }
         console.log("[3] 🔑 VS Code GitHub 세션 확보");
-        const repo = await (0, github_1.getSavedRepoInfo)(context);
+        const repo = (0, github_1.getSavedRepoInfo)(context);
         if (!repo) {
             panel.webview.postMessage({
                 command: "error",

--- a/out/github/repository/deleteSavedRepo.js
+++ b/out/github/repository/deleteSavedRepo.js
@@ -42,7 +42,7 @@ const Constants_1 = require("./Constants");
 const getSavedRepoInfo_1 = __importDefault(require("./getSavedRepoInfo"));
 const formatRepoInfo_1 = __importDefault(require("./formatRepoInfo"));
 async function deleteSavedRepo(context) {
-    const savedRepoInfo = await (0, getSavedRepoInfo_1.default)(context);
+    const savedRepoInfo = (0, getSavedRepoInfo_1.default)(context);
     if (!savedRepoInfo) {
         vscode.window.showInformationMessage("저장된 레포가 없습니다.");
         return;

--- a/out/github/vscodeAuth/getExistingGithubSession.js
+++ b/out/github/vscodeAuth/getExistingGithubSession.js
@@ -8,8 +8,8 @@ const getGithubSession_1 = __importDefault(require("./getGithubSession"));
 async function getExistingGitHubSession() {
     try {
         const silent = true;
-        const session = await (0, getGithubSession_1.default)(silent);
-        return session ?? undefined;
+        const session = await (0, getGithubSession_1.default)(false, silent);
+        return session;
     }
     catch {
         return undefined;

--- a/out/github/vscodeAuth/isSignOutGithub.js
+++ b/out/github/vscodeAuth/isSignOutGithub.js
@@ -43,21 +43,33 @@ const Constants_1 = require("./Constants");
 async function isSignOutGitHub() {
     // 1) 세션이 없으면 바로 종료
     const existing = await (0, getExistingGithubSession_1.default)();
-    if (!existing)
-        return true;
-    // 2) 가장 호환성 좋은 기본 명령 시도
-    try {
-        await vscode.commands.executeCommand("github.signout");
+    console.log("[로그아웃] 1. 기존 세션 확인:", existing ? "세션 있음" : "세션 없음");
+    if (!existing) {
+        console.log("[로그아웃] 세션이 없어서 종료");
         return true;
     }
-    catch { }
-    // 3) 워크벤치 계정 패널 경유(환경별로 지원/미지원 가능)
+    // 2) VS Code Authentication API의 removeSession 사용
     try {
-        await vscode.commands.executeCommand("workbench.action.accounts.signOutOfAuthenticationProvider", { id: Constants_1.GITHUB_PROVIDER, label: "GitHub" });
+        console.log("[로그아웃] 2. removeSession 시도 중...", existing.account.label);
+        // vscode.authentication.getSession으로 얻은 세션을 제거
+        const sessions = await vscode.authentication.getAccounts(Constants_1.GITHUB_PROVIDER);
+        console.log("[로그아웃] 현재 GitHub 계정 목록:", sessions);
+        // 모든 GitHub 세션 제거
+        await vscode.authentication.getSession(Constants_1.GITHUB_PROVIDER, [], {
+            clearSessionPreference: true,
+            createIfNone: false
+        });
+        console.log("[로그아웃] ✅ 로그아웃 성공");
+        vscode.window.showInformationMessage(`GitHub 로그아웃 완료: ${existing.account.label}`);
         return true;
     }
-    catch { }
-    // 4) 마지막 안내
-    vscode.window.showInformationMessage("로그아웃 명령을 사용할 수 없습니다. 좌측 하단 Accounts(계정) 메뉴에서 GitHub 계정을 수동으로 Sign Out 해주세요.");
-    return false;
+    catch (err) {
+        console.error("[로그아웃] ❌ 로그아웃 실패:", err);
+        // Fallback: 사용자에게 수동 로그아웃 안내
+        const openAccounts = await vscode.window.showWarningMessage("자동 로그아웃에 실패했습니다. Accounts 메뉴를 열어드릴까요?", "Accounts 열기", "취소");
+        if (openAccounts === "Accounts 열기") {
+            await vscode.commands.executeCommand("workbench.actions.manage");
+        }
+        return false;
+    }
 }

--- a/out/llm/analyze.js
+++ b/out/llm/analyze.js
@@ -2,6 +2,11 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.analyzePrompts = analyzePrompts;
 const openai_1 = require("openai");
+// export type LLMResult = {
+//   summary: string;
+//   rootCause: string;
+//   suggestion: string;
+// };
 function parseJsonLenient(text) {
     // ```json ... ``` 같은 코드펜스 제거
     const stripped = text.replace(/```(?:json)?/gi, "").replace(/```/g, "").trim();
@@ -12,6 +17,7 @@ function parseJsonLenient(text) {
         : stripped;
     let parsed;
     try {
+        // const parsed = JSON.parse(candidate);
         parsed = JSON.parse(candidate);
     }
     catch {
@@ -21,6 +27,15 @@ function parseJsonLenient(text) {
             suggestion: "",
             confidence: 0.2,
         };
+        //   return {
+        //     summary: String(parsed.summary ?? ""),
+        //     rootCause: String(parsed.rootCause ?? ""),
+        //     suggestion: String(parsed.suggestion ?? ""),
+        //   };
+        // } catch {
+        //   // 파싱 실패 → 원문을 summary에 넣어 반환
+        //   return { summary: text, rootCause: "", suggestion: "" };
+        // }
     }
     const asString = (v) => (v == null ? "" : String(v));
     const asNumber01 = (v) => {

--- a/out/log/extractRelevantLog.js
+++ b/out/log/extractRelevantLog.js
@@ -1,7 +1,7 @@
 "use strict";
+// // src/log/extractRelevantLog.ts
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.extractRelevantLog = extractRelevantLog;
-// src/log/extractRelevantLog.ts
 function extractRelevantLog(content, mode = 'all', options) {
     const tailLines = options?.tailLines ?? 800;
     const errorWindow = options?.errorWindow ?? 300;

--- a/src/github/vscodeAuth/isSignOutGithub.ts
+++ b/src/github/vscodeAuth/isSignOutGithub.ts
@@ -3,28 +3,29 @@ import getExistingGithubSession from "./getExistingGithubSession";
 import { GITHUB_PROVIDER } from "./Constants";
 
 export default async function isSignOutGitHub(): Promise<boolean> {
-  // 1) 세션이 없으면 바로 종료
   const existing = await getExistingGithubSession();
-  if (!existing) return true;
-
-  // 2) 가장 호환성 좋은 기본 명령 시도
-  try {
-    await vscode.commands.executeCommand("github.signout");
+  if (!existing) {
     return true;
-  } catch {}
+  }
 
-  // 3) 워크벤치 계정 패널 경유(환경별로 지원/미지원 가능)
   try {
-    await vscode.commands.executeCommand(
-      "workbench.action.accounts.signOutOfAuthenticationProvider",
-      { id: GITHUB_PROVIDER, label: "GitHub" }
+    await vscode.authentication.getSession(GITHUB_PROVIDER, [], {
+      clearSessionPreference: true,
+      createIfNone: false
+    });
+
+    vscode.window.showInformationMessage(`GitHub 로그아웃 완료: ${existing.account.label}`);
+    return true;
+  } catch (err) {
+    const openAccounts = await vscode.window.showWarningMessage(
+      "자동 로그아웃에 실패했습니다. Accounts 메뉴를 열어드릴까요?",
+      "Accounts 열기",
+      "취소"
     );
-    return true;
-  } catch {}
 
-  // 4) 마지막 안내
-  vscode.window.showInformationMessage(
-    "로그아웃 명령을 사용할 수 없습니다. 좌측 하단 Accounts(계정) 메뉴에서 GitHub 계정을 수동으로 Sign Out 해주세요."
-  );
-  return false;
+    if (openAccounts === "Accounts 열기") {
+      await vscode.commands.executeCommand("workbench.actions.manage");
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
## GitHub Logout 기능 수정

  ### 변경 사항
  - VS Code Authentication API를 사용한 프로그래밍 방식의 로그아웃 구현
  - `clearSessionPreference` 옵션으로 세션 자동 제거
  - 실패 시 Accounts 메뉴 열기 fallback 추가

  ### 문제점
  기존 코드는 `github.signout`, `workbench.action.accounts.signOutOfAuthenticationProvider`
  명령어를 사용했으나, VS Code에서 해당 명령어들을 제공하지 않아 로그아웃이 불가능했습니다.

  ### 해결
  `vscode.authentication.getSession()`의 `clearSessionPreference: true` 옵션을 사용하여
  프로그래밍 방식으로 GitHub 세션을 제거하도록 수정했습니다.

  ### 수정 파일
  - `src/github/vscodeAuth/isSignOutGithub.ts`