### PR TITLE
refactor: 첫 화면으로 `history` 페이지가 나오도록 변경

### DIFF
--- a/src/webview-react-app/src/components/Sidebar/Sidebar.tsx
+++ b/src/webview-react-app/src/components/Sidebar/Sidebar.tsx
@@ -66,18 +66,6 @@ const Sidebar: React.FC<SidebarProps> = ({
               {selectedActionId === action.id && dropdownActive && (
                   <div className="action-dropdown">
                     <div 
-                      className={`dropdown-item ${activePage === 'editor' ? 'selected' : ''}`}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onSelectPage('editor');
-                      }}
-                    >
-                      <span className="dropdown-icon">
-                        <EditorIcon />
-                      </span>
-                      <span>Editor</span>
-                    </div>
-                    <div 
                       className={`dropdown-item ${activePage === 'history' ? 'selected' : ''}`}
                       onClick={(e) => {
                         e.stopPropagation();
@@ -88,6 +76,18 @@ const Sidebar: React.FC<SidebarProps> = ({
                         <HistoryIcon />
                       </span>
                       <span>Run History</span>
+                    </div>
+                    <div 
+                      className={`dropdown-item ${activePage === 'editor' ? 'selected' : ''}`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onSelectPage('editor');
+                      }}
+                    >
+                      <span className="dropdown-icon">
+                        <EditorIcon />
+                      </span>
+                      <span>Editor</span>
                     </div>
                   </div>
               )}


### PR DESCRIPTION
추가 작업 내용 :
- 사이드바에서 폴더 선택했을때 history 페이지로 이동하지 말고 현재 페이지에 대기하도록 변경
- `Run Log`페이지가 랜더링되기 전까진 페이지 이동 막기