### PR TITLE
feat(llm): LLM 분석 파이프라인을 1차/2차 구조로 분리

### DIFF
--- a/src/llm/prompts.ts
+++ b/src/llm/prompts.ts
@@ -1,0 +1,82 @@
+// src/llm/prompts.ts
+import type { SecondPassInput, SuspectedPath } from "./types";
+
+/**
+ * 1차(로그만) 분석용 프롬프트 빌더
+ * - 로그 조각(핵심 발췌) 하나를 받아 LLM이 요약/원인/제안/키에러(+선택적으로 suspectedPaths)까지 뽑도록 유도
+ * - analyze.ts에서 system 지침은 별도로 넣고, 이 함수는 user 메시지 content만 넘긴다는 가정
+ */
+export function buildFirstPassPrompt(logChunk: string): string {
+  const guide = [
+    "다음은 GitHub Actions 실패 로그의 일부입니다.",
+    "핵심만 분석하여 JSON만 출력하세요. 마크다운, 코드펜스, 설명 문장 금지.",
+    "",
+    "요구 키:",
+    "- summary: 2~3문장 요약(~습니다).",
+    "- rootCause: 실패의 핵심 원인 한 문장(~습니다).",
+    "- suggestion: 즉시 시도 가능한 조치(명령어/파일경로/설정키 등 구체적, ~합니다).",
+    "- failureType: dependency|network|tooling|permissions|config|test|infra 중 하나 권장.",
+    "- confidence: 0~1 숫자.",
+    "- affectedStep: 관련된 CI 스텝명(있으면).",
+    "- filename: 분석 로그 파일명/섹션명(있으면).",
+    "- keyErrors: [{ line, snippet, note }].",
+    // 필요시 의심 경로도 함께 뽑고 싶다면 주석 해제
+    // "- suspectedPaths: [{ path, reason, score, linesHint }]",
+    "",
+    "절대 금지:",
+    "- 지침/예시/해설을 결과에 포함하지 마세요.",
+    "- 사고과정(chain-of-thought) 노출 금지.",
+    "",
+    "로그 조각:",
+  ];
+  return [guide.join("\n"), logChunk].join("\n");
+}
+
+/**
+ * 2차(로그+코드) 정밀 분석 프롬프트 빌더
+ * - 선택된 의심 지점에 대해: 로그 발췌 + 코드 윈도우를 동시 제공
+ * - LLM이 파일/라인/패치(unified diff)/체크리스트까지 반환하도록 강제
+ */
+export function buildSecondPassPrompt(input: SecondPassInput): string {
+  const { path, logExcerpt, codeWindow, lineHint, context } = input;
+
+  const header = [
+    "다음은 특정 의심 지점에 대한 정밀 분석 요청입니다.",
+    "입력으로 CI 실패 로그 발췌와 해당 파일의 코드 윈도우를 제공합니다.",
+    "분석 결과는 반드시 JSON만 출력합니다. 마크다운/설명/코드펜스 금지.",
+    "",
+    "반드시 포함할 키:",
+    '- file: 문제 파일 경로(문자열, 예: "src/app.ts").',
+    "- startLine: 패치 시작 라인(가능하면 추정).",
+    "- endLine: 패치 끝 라인(가능하면 추정).",
+    '- unifiedDiff: UNIX unified diff 포맷 문자열(---/+++/@@ 포함).',
+    "- checklist: PR 전 수동 확인 항목 배열(각 항목 ~하세요/~입니다).",
+    "- confidence: 0~1 숫자.",
+    "",
+    "추가 지침:",
+    "- 패치는 최소 수정 원칙을 따르세요.",
+    "- 만약 환경/네트워크 이슈 등 코드 변경이 부적절하면 unifiedDiff는 빈 문자열로 두고 checklist에 조치 사항을 구체적으로 제시하세요.",
+    "- 사고과정(chain-of-thought) 노출 금지.",
+    "",
+    `대상 파일 경로: ${path}`,
+    lineHint ? `의심 라인 힌트: ${lineHint}` : undefined,
+    context?.workflow ? `워크플로우: ${context.workflow}` : undefined,
+    context?.step ? `스텝: ${context.step}` : undefined,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const sections = [
+    header,
+    "",
+    "=== 실패 로그 발췌 시작 ===",
+    logExcerpt.trim(),
+    "=== 실패 로그 발췌 끝 ===",
+    "",
+    "=== 코드 윈도우 시작 ===",
+    codeWindow.trim(),
+    "=== 코드 윈도우 끝 ===",
+  ];
+
+  return sections.join("\n");
+}

--- a/src/llm/suspects.ts
+++ b/src/llm/suspects.ts
@@ -1,0 +1,193 @@
+// src/llm/suspects.ts
+import type { SuspectedPath } from "./types";
+
+/**
+ * 실패 로그에서 파일/라인 패턴을 찾아 의심 지점을 추출하고 간단 스코어를 매겨 반환.
+ * - 언어/툴별 흔한 포맷 정규식 포함 (TS/JS 스택, Python, Java, Go, ESLint/TS/Jest 등)
+ * - 각 매칭 지점 주변으로 로그 발췌(logExcerpt)를 만들어 2차 프롬프트에 바로 사용 가능
+ */
+export function extractSuspects(
+  logText: string,
+  opts?: { max?: number; excerptPadding?: number }
+): SuspectedPath[] {
+  const MAX = opts?.max ?? 10;
+  const PADDING = opts?.excerptPadding ?? 40; // 매칭 근처 전후 줄 수
+
+  const lines = splitLines(logText);
+  const candidates: SuspectCandidate[] = [];
+
+  // 정규식 패턴 세트
+  const patterns: PatternSpec[] = [
+    // 1) TS/JS 스택트레이스: at Foo (src/app.ts:123:45)
+    {
+      name: "jsStack",
+      regex: /\b(?:at\s+[^\s(]+)?\s*\(?([A-Za-z0-9_./-]+\.(?:ts|tsx|js|jsx|mjs|cjs)):(\d+)(?::\d+)?\)?/g,
+      weight: 0.5,
+    },
+    // 2) 일반 파일:라인:열 (webpack 등)
+    {
+      name: "genericColon",
+      regex: /\b([A-Za-z0-9_./-]+\.(?:ts|tsx|js|jsx|mjs|cjs|css|scss|vue|go|py|java|kt|rb|rs|cs|cpp|c|h)):(\d+)(?::\d+)?\b/g,
+      weight: 0.45,
+    },
+    // 3) Python: File "app.py", line 210
+    {
+      name: "python",
+      regex: /File\s+"([A-Za-z0-9_./-]+\.py)",\s+line\s+(\d+)/g,
+      weight: 0.5,
+    },
+    // 4) Java: (Foo.java:57)
+    {
+      name: "java",
+      regex: /\(([A-Za-z0-9_./-]+\.java):(\d+)\)/g,
+      weight: 0.5,
+    },
+    // 5) Go: path/file.go:123 + 함수명 등
+    {
+      name: "go",
+      regex: /\b([A-Za-z0-9_./-]+\.go):(\d+)\b/g,
+      weight: 0.45,
+    },
+    // 6) ESLint: path/file.ts:10:5 - Rule message
+    {
+      name: "eslint",
+      regex: /\b([A-Za-z0-9_./-]+\.(?:ts|tsx|js|jsx)):(\d+):\d+\s+-\s+/g,
+      weight: 0.55,
+    },
+    // 7) TypeScript tsc: path/file.ts(123,7): error TSxxxx
+    {
+      name: "tsc",
+      regex: /\b([A-Za-z0-9_./-]+\.tsx?)\((\d+),\d+\):\s+error\s+TS\d+/g,
+      weight: 0.55,
+    },
+    // 8) Jest: at Object.<anonymous> (src/foo.test.ts:88:11)
+    {
+      name: "jest",
+      regex: /\(([A-Za-z0-9_./-]+\.(?:test|spec)\.tsx?):(\d+):\d+\)/g,
+      weight: 0.5,
+    },
+  ];
+
+  // 라인별로 패턴 스캔
+  lines.forEach((line, idx) => {
+    for (const p of patterns) {
+      p.regex.lastIndex = 0; // 안전: 전역 정규식 포인터 리셋
+      let m: RegExpExecArray | null;
+      while ((m = p.regex.exec(line)) !== null) {
+        const rawPath = m[1];
+        const lineNum = safeInt(m[2]);
+        if (!rawPath) continue;
+        const path = normalizePath(rawPath);
+
+        const reason = `[${p.name}] ${line.trim().slice(0, 240)}`;
+        const logExcerpt = makeExcerpt(lines, idx, PADDING);
+
+        const baseScore = p.weight;
+        const exactLineBonus = lineNum ? 0.3 : 0;
+        const fileDepthBonus = path.includes("/") ? 0.1 : 0; // 대충 src/.. 등
+        const penaltyGen = isGeneratedOrVendor(path) ? -0.2 : 0;
+
+        const score = clamp01(baseScore + exactLineBonus + fileDepthBonus + penaltyGen);
+
+        candidates.push({
+          path,
+          lineHint: lineNum ?? undefined,
+          score,
+          reason,
+          excerpt: logExcerpt,
+          hitLineIndex: idx,
+        });
+      }
+    }
+  });
+
+  // 중복 제거: 같은 path + lineHint는 하나로
+  const dedupMap = new Map<string, SuspectCandidate>();
+  for (const c of candidates) {
+    const key = `${c.path}#${c.lineHint ?? "?"}`;
+    const prev = dedupMap.get(key);
+    if (!prev || c.score > prev.score) {
+      dedupMap.set(key, c);
+    }
+  }
+
+  // 정렬 + 상위 N 슬라이스
+  const deduped = Array.from(dedupMap.values())
+    .sort((a, b) => b.score - a.score)
+    .slice(0, MAX);
+
+  // SuspectedPath 형태로 변환
+  const result: SuspectedPath[] = deduped.map((c) => ({
+    path: c.path,
+    reason: c.reason,
+    score: clamp01(c.score),
+    lineHint: c.lineHint,
+    logExcerpt: c.excerpt,
+  }));
+
+  return result;
+}
+
+/* 내부 타입 */
+type SuspectCandidate = {
+  path: string;
+  lineHint?: number;
+  score: number;
+  reason: string;
+  excerpt: string;
+  hitLineIndex: number;
+};
+
+type PatternSpec = {
+  name: string;
+  regex: RegExp;
+  weight: number; // 기본 가중치
+};
+
+/* 유틸들 */
+
+function splitLines(text: string): string[] {
+  // 윈도우/유닉스 개행 모두 대응
+  return text.split(/\r?\n/);
+}
+
+function makeExcerpt(lines: string[], centerIndex: number, padding: number): string {
+  const start = Math.max(0, centerIndex - padding);
+  const end = Math.min(lines.length, centerIndex + padding + 1);
+  return lines.slice(start, end).join("\n").trim();
+}
+
+function normalizePath(p: string): string {
+  // 백슬래시 -> 슬래시, 중복 슬래시 정리
+  return p.replace(/\\/g, "/").replace(/\/+/g, "/");
+}
+
+function safeInt(v: any): number | undefined {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function clamp01(n: number): number {
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}
+
+function isGeneratedOrVendor(path: string): boolean {
+  // 노이즈/생성물/서드파티: 점수 약간 패널티
+  return (
+    /(^|\/)(dist|out|build|coverage|vendor|node_modules)(\/|$)/.test(path) ||
+    /\.min\.(js|css)$/.test(path) ||
+    /\.map$/.test(path)
+  );
+}
+
+/* 참고: 필요한 최소 타입 (types.ts에 없으면 추가)
+export type SuspectedPath = {
+  path: string;
+  reason: string;
+  score?: number;
+  lineHint?: number;
+  logExcerpt?: string;
+};
+*/

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -5,15 +5,51 @@ export type LLMKeyError = {
   note?: string;    // 왜 중요한지
 };
 
+export type FailureType =
+  | "dependency" | "network" | "tooling" | "permissions" | "config" | "test" | "infra";
+
+// 로그 1차 분석 결과 구조
 export type LLMResult = {
   summary: string;      // 전체 요약
   rootCause: string;    // 실패의 핵심 원인(한 문장)
   suggestion: string;   // 구체적 해결 방법
 
-  // 선택
-  failureType?: string;   // dependency | network | tooling | permissions | config | test | infra
+  failureType?: FailureType;   // dependency | network | tooling | permissions | config | test | infra
   confidence?: number;    // 0~1 신뢰도
   affectedStep?: string;  // 분석 대상 스텝명(있으면)
   filename?: string;      // 분석 대상 파일명(있으면)
   keyErrors?: LLMKeyError[]; // 근거 라인/스니펫/메모
+
+  suspectedPaths?: SuspectedPath[];
+};
+
+// UI에 보여질 의심 경로 정보 → 택 1 해서 2차 LLM 분석 
+export type SuspectedPath = {
+  path: string;        // repo 상대 경로
+  reason: string;      // 왜 후보인지(매칭된 로그 라인 요약)
+  score?: number;      // 0~1 가중치
+  lineHint?: number;   // 의심 라인 번호(있으면)
+  logExcerpt?: string; // 로그 발췌(해당 근처 N줄)
+};
+
+// 2차 분석 입력 : UI 에 전달하지 말기
+export type SecondPassInput = {
+  path: string;             // 문제 파일 경로
+  logExcerpt: string;       // 실패 로그 발췌
+  codeWindow: string;       // 의심 라인 주변 ±N줄 코드
+  lineHint?: number;        // 중심 라인(있으면)
+  context?: {               // 선택적 메타데이터
+    workflow?: string;      // CI 워크플로우 이름
+    step?: string;          // 실패 스텝 이름
+  };
+};
+
+// 2차 분석 결과 : UI 에 보여주기
+export type PinpointResult = {
+  file: string;          // 문제 파일
+  startLine?: number;    // 수정 시작 라인
+  endLine?: number;      // 수정 끝 라인
+  unifiedDiff?: string;  // ---/+++/@@ 포함 diff
+  checklist?: string[];  // PR 전 수동 확인 항목
+  confidence?: number;   // 신뢰도 0~1
 };


### PR DESCRIPTION
- 1차(로그 기반) 분석: analyzePrompts → summary/rootCause/suggestion 등 JSON 반환
- 2차(로그+코드 기반) 분석: SecondPassInput/PinpointResult 타입 정의 및 prompts 빌더 추가
- src/llm/
  - analyze.ts : 1차 분석 로직 (suspectedPaths 보강 포함)
  - prompts.ts : 1차/2차 프롬프트 빌더
  - suspects.ts : 로그에서 의심 파일/라인 추출
  - types.ts : LLMResult / SuspectedPath / SecondPassInput / PinpointResult 타입 정의
- 1차 결과 기반으로 suspectedPaths 추출 후 2차 정밀 분석 확장 가능

연결된 이슈: #49 